### PR TITLE
Update http_status_code.py

### DIFF
--- a/http_status_code.py
+++ b/http_status_code.py
@@ -5,11 +5,12 @@ Github: https://github.com/ilstar/http_status_code
 Author: Fred Liang
 '''
 
+import sys
 import csv
 
 from feedback import Feedback
 
-query = '{query}'
+query = sys.argv[1]
 query = query.lower()
 baseurl = 'https://httpstatuses.com/'
 


### PR DESCRIPTION
So that we can call the code from bash instead of directly (making this change because /usr/bin/python is gone since MacOS Monterey)